### PR TITLE
Rebase local patches over upstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,6 @@ set ( ly_common_source_files
 file ( GLOB_RECURSE	ly_unittest_sources ${ly_tst_dir}/*.cc )
 list ( SORT			ly_unittest_sources )
 
-include_directories( BEFORE ${ly_inc_dir} )
-
 if(MSVC)
   add_definitions ( -D_CRT_SECURE_NO_WARNINGS )
 endif()
@@ -84,6 +82,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # Build the set of objects that do not need to be compiled with flags to enable
 # particular architecture features.
 add_library( ${ly_lib_name}_common_objects OBJECT ${ly_common_source_files} )
+target_include_directories( ${ly_lib_name}_common_objects PRIVATE $<BUILD_INTERFACE:${ly_inc_dir}>)
 set(ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_common_objects>)
 
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" SYSPROC)
@@ -106,6 +105,7 @@ if(NOT MSVC)
       ${ly_src_dir}/row_neon.cc
       ${ly_src_dir}/scale_neon.cc)
     target_compile_options(${ly_lib_name}_neon PRIVATE -mfpu=neon)
+    target_include_directories(${ly_lib_name}_neon PRIVATE $<BUILD_INTERFACE:${ly_inc_dir}>)
     list(APPEND ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_neon>)
   endif()
 
@@ -117,12 +117,14 @@ if(NOT MSVC)
       ${ly_src_dir}/row_neon64.cc
       ${ly_src_dir}/scale_neon64.cc)
     target_compile_options(${ly_lib_name}_neon64 PRIVATE -march=armv8.2-a+dotprod+i8mm)
+    target_include_directories(${ly_lib_name}_neon64 PRIVATE $<BUILD_INTERFACE:${ly_inc_dir}>)
     list(APPEND ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_neon64>)
 
     # Enable AArch64 SVE kernels.
     add_library(${ly_lib_name}_sve OBJECT
       ${ly_src_dir}/row_sve.cc)
     target_compile_options(${ly_lib_name}_sve PRIVATE -march=armv8.5-a+i8mm+sve2)
+    target_include_directories(${ly_lib_name}_sve PRIVATE $<BUILD_INTERFACE:${ly_inc_dir}>)
     list(APPEND ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_sve>)
 
     set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
@@ -145,6 +147,7 @@ int main(void) { return 0; }
         ${ly_src_dir}/row_sme.cc
         ${ly_src_dir}/scale_sme.cc)
       target_compile_options(${ly_lib_name}_sme PRIVATE -march=armv9-a+i8mm+sme)
+      target_include_directories(${ly_lib_name}_sme PRIVATE $<BUILD_INTERFACE:${ly_inc_dir}>)
       list(APPEND ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_sme>)
     else()
       add_definitions(-DLIBYUV_DISABLE_SME)
@@ -177,8 +180,14 @@ if(LOONGARCH64)
   endif()
 endif()
 
-ADD_LIBRARY	(${ly_lib_name} ${ly_source_files} )
+ADD_LIBRARY	(${ly_lib_name} ${ly_lib_parts} )
 ADD_LIBRARY(Libyuv::Libyuv ALIAS ${ly_lib_name})
+
+TARGET_INCLUDE_DIRECTORIES(${ly_lib_name}
+  PUBLIC
+    $<BUILD_INTERFACE:${ly_inc_dir}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 
 if (WITH_TOOLS)
   # this creates the conversion tool

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ if(UNIT_TEST)
   endif()
 endif()
 
-set_target_properties(${ly_lib_name} PROPERTIES EXPORT_NAME Libyuv)
+set_target_properties(${ly_lib_name} PROPERTIES EXPORT_NAME Libyuv POSITION_INDEPENDENT_CODE ON)
 INSTALL ( TARGETS ${ly_lib_name}
   EXPORT ${ly_lib_name}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,15 +6,19 @@ cmake_minimum_required( VERSION 3.16 )
 project ( YUV C CXX )	# "C" is required even for C++ projects
 option( UNIT_TEST "Built unit tests" OFF )
 
-include(CheckCSourceCompiles)
+OPTION(WITH_TOOLS "Build tools" OFF)
+OPTION(WITH_JPEG "Enable JPEG support" OFF)
 
-set ( ly_base_dir	${PROJECT_SOURCE_DIR} )
-set ( ly_src_dir	${ly_base_dir}/source )
-set ( ly_inc_dir	${ly_base_dir}/include )
-set ( ly_tst_dir	${ly_base_dir}/unit_test )
-set ( ly_lib_name	yuv )
-set ( ly_lib_static	${ly_lib_name} )
-set ( ly_lib_shared	${ly_lib_name}_shared )
+INCLUDE(GNUInstallDirs)
+INCLUDE(CMakePackageConfigHelpers)
+INCLUDE(CheckCSourceCompiles)
+
+SET ( ly_base_dir	${PROJECT_SOURCE_DIR} )
+SET ( ly_src_dir	${ly_base_dir}/source )
+SET ( ly_inc_dir	${ly_base_dir}/include )
+SET ( ly_tst_dir	${ly_base_dir}/unit_test )
+SET ( ly_lib_name	yuv )
+SET ( ly_lib_filename	"lib${ly_lib_name}" )
 
 # We cannot use GLOB here since we want to be able to separate out files that
 # need particular flags to enable architecture extensions like AArch64's SVE.
@@ -173,34 +177,26 @@ if(LOONGARCH64)
   endif()
 endif()
 
-# this creates the static library (.a)
-add_library( ${ly_lib_static} STATIC ${ly_lib_parts})
+ADD_LIBRARY	(${ly_lib_name} ${ly_source_files} )
+ADD_LIBRARY(Libyuv::Libyuv ALIAS ${ly_lib_name})
 
-# this creates the shared library (.so)
-add_library( ${ly_lib_shared} SHARED ${ly_lib_parts})
-set_target_properties( ${ly_lib_shared} PROPERTIES OUTPUT_NAME "${ly_lib_name}" )
-set_target_properties( ${ly_lib_shared} PROPERTIES PREFIX "lib" )
-if(WIN32)
-  set_target_properties( ${ly_lib_shared} PROPERTIES IMPORT_PREFIX "lib" )
+if (WITH_TOOLS)
+  # this creates the conversion tool
+  ADD_EXECUTABLE			( yuvconvert ${ly_base_dir}/util/yuvconvert.cc )
+  TARGET_LINK_LIBRARIES	( yuvconvert ${ly_lib_name} )
+
+  # this creates the yuvconstants tool
+  ADD_EXECUTABLE      ( yuvconstants ${ly_base_dir}/util/yuvconstants.c )
+  TARGET_LINK_LIBRARIES  ( yuvconstants ${ly_lib_name} )
 endif()
 
-# this creates the cpuid tool
-add_executable      ( cpuid ${ly_base_dir}/util/cpuid.c )
-target_link_libraries  ( cpuid ${ly_lib_static} )
-
-# this creates the conversion tool
-add_executable			( yuvconvert ${ly_base_dir}/util/yuvconvert.cc )
-target_link_libraries	( yuvconvert ${ly_lib_static} )
-
-# this creates the yuvconstants tool
-add_executable      ( yuvconstants ${ly_base_dir}/util/yuvconstants.c )
-target_link_libraries  ( yuvconstants ${ly_lib_static} )
-
-find_package ( JPEG )
-if (JPEG_FOUND)
-  include_directories( ${JPEG_INCLUDE_DIR} )
-  target_link_libraries( ${ly_lib_shared} ${JPEG_LIBRARY} )
-  add_definitions( -DHAVE_JPEG )
+if (WITH_JPEG)
+  find_package ( JPEG )
+  if (JPEG_FOUND)
+    target_include_directories(${ly_lib_name} PRIVATE ${JPEG_INCLUDE_DIR} )
+    target_link_libraries(${ly_lib_name} PRIVATE ${JPEG_LIBRARY} )
+    target_compile_definitions(${ly_lib_name} PRIVATE HAVE_JPEG )
+  endif()
 endif()
 
 if(UNIT_TEST)
@@ -244,12 +240,42 @@ if(UNIT_TEST)
   endif()
 endif()
 
+set_target_properties(${ly_lib_name} PROPERTIES EXPORT_NAME Libyuv)
+INSTALL ( TARGETS ${ly_lib_name}
+  EXPORT ${ly_lib_name}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  COMPONENT devel
+)
 
-# install the conversion tool, .so, .a, and all the header files
-install ( TARGETS yuvconvert DESTINATION bin )
-install ( TARGETS ${ly_lib_static}						DESTINATION lib )
-install ( TARGETS ${ly_lib_shared} LIBRARY DESTINATION lib RUNTIME DESTINATION bin ARCHIVE DESTINATION lib )
-install ( DIRECTORY ${PROJECT_SOURCE_DIR}/include/		DESTINATION include )
+INSTALL (DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  COMPONENT devel)
+
+configure_package_config_file(cmake/${ly_lib_filename}Config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${ly_lib_filename}Config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${ly_lib_filename}
+    PATH_VARS
+        CMAKE_INSTALL_INCLUDEDIR
+        CMAKE_INSTALL_LIBDIR)
+
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/${ly_lib_filename}Config.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${ly_lib_filename}
+  COMPONENT devel)
+
+install(
+  EXPORT ${ly_lib_name}
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${ly_lib_filename}
+  FILE ${ly_lib_filename}Targets.cmake
+  NAMESPACE Libyuv::)
+
+if (WITH_TOOLS)
+  INSTALL ( PROGRAMS
+    ${CMAKE_BINARY_DIR}/yuvconvert
+    ${CMAKE_BINARY_DIR}/yuvconstants
+    DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif()
 
 # create the .deb and .rpm packages using cpack
 include ( CM_linux_packages.cmake )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,13 +277,15 @@ install(
   EXPORT ${ly_lib_name}
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${ly_lib_filename}
   FILE ${ly_lib_filename}Targets.cmake
-  NAMESPACE Libyuv::)
+  NAMESPACE Libyuv::
+  COMPONENT devel)
 
 if (WITH_TOOLS)
   INSTALL ( PROGRAMS
     ${CMAKE_BINARY_DIR}/yuvconvert
     ${CMAKE_BINARY_DIR}/yuvconstants
-    DESTINATION ${CMAKE_INSTALL_BINDIR} )
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT application)
 endif()
 
 # create the .deb and .rpm packages using cpack

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ OPTION(WITH_JPEG "Enable JPEG support" OFF)
 INCLUDE(GNUInstallDirs)
 INCLUDE(CMakePackageConfigHelpers)
 INCLUDE(CheckCSourceCompiles)
+INCLUDE(CheckCCompilerFlag)
 
 SET ( ly_base_dir	${PROJECT_SOURCE_DIR} )
 SET ( ly_src_dir	${ly_base_dir}/source )
@@ -93,6 +94,7 @@ if(LOONGARCH64MATCH GREATER "-1")
   set(LOONGARCH64 1)
 endif()
 
+
 if(NOT MSVC)
   string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" arch_lowercase)
 
@@ -111,21 +113,34 @@ if(NOT MSVC)
 
   if(arch_lowercase STREQUAL "aarch64" OR arch_lowercase STREQUAL "arm64")
     # Enable AArch64 Neon dot-product and i8mm kernels.
+    check_c_source_compiles("-march=armv8.2-a+dotprod+i8mm" CAN_COMPILE_I8MM)
     add_library(${ly_lib_name}_neon64 OBJECT
       ${ly_src_dir}/compare_neon64.cc
       ${ly_src_dir}/rotate_neon64.cc
       ${ly_src_dir}/row_neon64.cc
       ${ly_src_dir}/scale_neon64.cc)
-    target_compile_options(${ly_lib_name}_neon64 PRIVATE -march=armv8.2-a+dotprod+i8mm)
+    if (CAN_COMPILE_I8MM)
+      target_compile_options(${ly_lib_name}_neon64 PRIVATE -march=armv8.2-a+dotprod+i8mm)
+    else()
+      message(STATUS "Disabling I8MM extensions")
+      target_compile_options(${ly_lib_name}_neon64 PRIVATE -march=armv8.2-a+dotprod)
+      add_definitions(-DLIBYUV_DISABLE_I8MM)
+    endif()
     target_include_directories(${ly_lib_name}_neon64 PRIVATE $<BUILD_INTERFACE:${ly_inc_dir}>)
     list(APPEND ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_neon64>)
 
     # Enable AArch64 SVE kernels.
-    add_library(${ly_lib_name}_sve OBJECT
-      ${ly_src_dir}/row_sve.cc)
-    target_compile_options(${ly_lib_name}_sve PRIVATE -march=armv8.5-a+i8mm+sve2)
-    target_include_directories(${ly_lib_name}_sve PRIVATE $<BUILD_INTERFACE:${ly_inc_dir}>)
-    list(APPEND ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_sve>)
+    check_c_source_compiles("-march=armv8.5-a+i8mm+sve2" CAN_COMPILE_SVE2)
+    if (CAN_COMPILE_SVE2)
+      add_library(${ly_lib_name}_sve OBJECT
+        ${ly_src_dir}/row_sve.cc)
+      target_compile_options(${ly_lib_name}_sve PRIVATE -march=armv8.5-a+i8mm+sve2)
+      target_include_directories(${ly_lib_name}_sve PRIVATE $<BUILD_INTERFACE:${ly_inc_dir}>)
+      list(APPEND ly_lib_parts $<TARGET_OBJECTS:${ly_lib_name}_sve>)
+    else()
+      message(STATUS "Disabling SVE extensions")
+      add_definitions(-DLIBYUV_DISABLE_SVE)
+    endif()
 
     set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
     set(OLD_CMAKE_TRY_COMPILE_TARGET_TYPE ${CMAKE_TRY_COMPILE_TARGET_TYPE})

--- a/cmake/libyuvConfig.cmake.in
+++ b/cmake/libyuvConfig.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(JPEG)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@ly_lib_filename@Targets.cmake")

--- a/cmake/libyuvConfig.cmake.in
+++ b/cmake/libyuvConfig.cmake.in
@@ -2,6 +2,8 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(JPEG)
+if (@WITH_JPEG@)
+    find_dependency(JPEG)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@ly_lib_filename@Targets.cmake")

--- a/include/libyuv/row.h
+++ b/include/libyuv/row.h
@@ -545,6 +545,7 @@ extern "C" {
 #define HAS_RGBATOYJROW_NEON_DOTPROD
 #define HAS_RGBATOYROW_NEON_DOTPROD
 
+#if !defined(LIBYUV_DISABLE_I8MM)
 #define HAS_ABGRTOUVJROW_NEON_I8MM
 #define HAS_ABGRTOUVROW_NEON_I8MM
 #define HAS_ARGBCOLORMATRIXROW_NEON_I8MM
@@ -554,6 +555,7 @@ extern "C" {
 #define HAS_ARGBTOUVROW_NEON_I8MM
 #define HAS_BGRATOUVROW_NEON_I8MM
 #define HAS_RGBATOUVROW_NEON_I8MM
+#endif
 #endif
 
 // The following are available on AArch64 SVE platforms:

--- a/source/row_neon64.cc
+++ b/source/row_neon64.cc
@@ -2778,6 +2778,7 @@ static void ARGBToUV444MatrixRow_NEON(
         "v27", "v28", "v29");
 }
 
+#if !defined(LIBYUV_DISABLE_I8MM)
 static void ARGBToUV444MatrixRow_NEON_I8MM(
     const uint8_t* src_argb,
     uint8_t* dst_u,
@@ -2814,6 +2815,7 @@ static void ARGBToUV444MatrixRow_NEON_I8MM(
       : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v16", "v17",
         "v29");
 }
+#endif
 
 // RGB to BT601 coefficients
 // UB   0.875 coefficient = 112
@@ -2834,6 +2836,7 @@ void ARGBToUV444Row_NEON(const uint8_t* src_argb,
                             &kARGBI601UVConstants);
 }
 
+#if !defined(LIBYUV_DISABLE_I8MM)
 void ARGBToUV444Row_NEON_I8MM(const uint8_t* src_argb,
                               uint8_t* dst_u,
                               uint8_t* dst_v,
@@ -2841,6 +2844,7 @@ void ARGBToUV444Row_NEON_I8MM(const uint8_t* src_argb,
   ARGBToUV444MatrixRow_NEON_I8MM(src_argb, dst_u, dst_v, width,
                                  &kARGBI601UVConstants);
 }
+#endif
 
 // RGB to JPEG coefficients
 // UB  0.500    coefficient = 128
@@ -2861,6 +2865,7 @@ void ARGBToUVJ444Row_NEON(const uint8_t* src_argb,
                             &kARGBJPEGUVConstants);
 }
 
+#if !defined(LIBYUV_DISABLE_I8MM)
 void ARGBToUVJ444Row_NEON_I8MM(const uint8_t* src_argb,
                                uint8_t* dst_u,
                                uint8_t* dst_v,
@@ -2868,6 +2873,7 @@ void ARGBToUVJ444Row_NEON_I8MM(const uint8_t* src_argb,
   ARGBToUV444MatrixRow_NEON_I8MM(src_argb, dst_u, dst_v, width,
                                  &kARGBJPEGUVConstants);
 }
+#endif
 
 #define RGBTOUV_SETUP_REG                                                  \
   "movi       v20.8h, #112          \n" /* UB/VR coefficient  (0.875)   */ \
@@ -3448,6 +3454,7 @@ void ARGB4444ToUVRow_NEON(const uint8_t* src_argb4444,
   );
 }
 
+#if !defined(LIBYUV_DISABLE_I8MM)
 // Process any of ARGB, ABGR, BGRA, RGBA, by adjusting the uvconstants layout.
 static void ABCDToUVMatrixRow_NEON_I8MM(const uint8_t* src,
                                         int src_stride,
@@ -3618,6 +3625,7 @@ void ABGRToUVJRow_NEON_I8MM(const uint8_t* src_abgr,
   ABCDToUVMatrixRow_NEON_I8MM(src_abgr, src_stride_abgr, dst_u, dst_v, width,
                               kABGRToUVJCoefficients);
 }
+#endif
 
 void RGB565ToYRow_NEON(const uint8_t* src_rgb565, uint8_t* dst_y, int width) {
   asm volatile(
@@ -4570,6 +4578,7 @@ void ARGBColorMatrixRow_NEON(const uint8_t* src_argb,
         "v17", "v18", "v19", "v22", "v23", "v24", "v25");
 }
 
+#if !defined(LIBYUV_DISABLE_I8MM)
 void ARGBColorMatrixRow_NEON_I8MM(const uint8_t* src_argb,
                                   uint8_t* dst_argb,
                                   const int8_t* matrix_argb,
@@ -4625,6 +4634,7 @@ void ARGBColorMatrixRow_NEON_I8MM(const uint8_t* src_argb,
       : "cc", "memory", "v0", "v1", "v16", "v17", "v18", "v19", "v20", "v21",
         "v22", "v23", "v31");
 }
+#endif
 
 // Multiply 2 rows of ARGB pixels together, 8 pixels at a time.
 void ARGBMultiplyRow_NEON(const uint8_t* src_argb,

--- a/source/row_sme.cc
+++ b/source/row_sme.cc
@@ -16,6 +16,8 @@ namespace libyuv {
 extern "C" {
 #endif
 
+#if !defined(LIBYUV_DISABLE_SVE) && defined(__aarch64__)
+
 #if !defined(LIBYUV_DISABLE_SME) && defined(CLANG_HAS_SME) && \
     defined(__aarch64__)
 
@@ -1176,6 +1178,7 @@ __arm_locally_streaming void RGBAToUVRow_SME(const uint8_t* src_rgba,
 
 #endif  // !defined(LIBYUV_DISABLE_SME) && defined(CLANG_HAS_SME) &&
         // defined(__aarch64__)
+#endif // !defined(LIBYUV_DISABLE_SVE) && defined(__aarch64__)
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
# Rationale for rebasing over current upstream

YUV->RGB conversion should respect color space and range.

YUYV->RGB conversion with option to choose color space becomes available at https://chromium.googlesource.com/libyuv/libyuv/+/914624f0b8b92986ef385e9650ee7b5fb07099e9

I have rebased our patches over current main branch.

# "Memory corruption" patch

The patch
```
commit 1aff270748b4d0324fc349dc975dc271d3b08c56
Author: Andrey Vostrikov <andrey.vostrikov@cogentembedded.com>
Date:   Mon Apr 24 13:28:57 2023 +0300

    Fix memory corruption at the end of buffer in SplitUVPlane, number of UV pairs is half of input image width
    
    Signed-off-by: Andrey Vostrikov <andrey.vostrikov@cogentembedded.com>
```
was dropped because it breaks all related tests by dropping half of the line.
I believe that in all invocations width corresponding to sub-sampling level is being supplied, and judging by `SplitUVRow_C` implementation it is correct (`width` = width of `dst_u`, `dst_v`; combined `uv` has double-width).

I have not checked if all implementations correctly handle non-vectorizeable leftowers, but if that is the case -- concrete  vectorized implementation should be checked.


# QNX 7.1 support

I have added an extra patch

```
commit 69fa0ab0e0a06058c295c91cce941e0b9b9fc21b
Author: Dmitriy Korchemkin <dmitrii.korchemkin@cogentembedded.com>
Date:   Fri Sep 19 15:27:23 2025 +0000

    Workaround for QNX compiler

```

While trying to build it for QNX target I discovered that `aarch64-unknown-nto-qnx7.1.0-g++` compiler chokes on `+i8mm` extension of `arm8.2-a` and on `sve2` extension of `armv8.5`
* For `sve2` I have reused `LIBYUV_DISABLE_SVE` that was already present in the code, but not in `CMakeLists.txt`
* For `i8mm` I have added `LIBYUV_DISABLE_I8MM`.

This fixes build for QNX 7.1.0

I would be glad if somebody with access to the hardware would build `libyuv` with tests and run them on the target hardware to be sure that everything is working as expected. 

(I do not intend to *merge* this per se, I think renaming old one would be much more reasonable)